### PR TITLE
Add CRC8 checker impemented in python

### DIFF
--- a/AHT20.py
+++ b/AHT20.py
@@ -106,7 +106,7 @@ class AHT20:
 
     def get_humidity(self):
         # Get a measure, select proper bytes, return converted data
-        measure = self.get_measure()
+        measure = self.get_measure_CRC8()
         measure = (measure[1] << 12) | (measure[2] << 4) | (measure[3] >> 4)
         measure = measure * 100 / pow(2,20)
         return measure
@@ -114,7 +114,7 @@ class AHT20:
     def get_humidity_crc8(self):
         isCRC8Pass = False
         while (not isCRC8Pass): 
-            measure, isCRC8Pass = self.get_measure()
+            measure, isCRC8Pass = self.get_measure_CRC8()
             time.sleep(80 * 10**-3)
         measure = (measure[1] << 12) | (measure[2] << 4) | (measure[3] >> 4)
         measure = measure * 100 / pow(2,20)

--- a/AHT20.py
+++ b/AHT20.py
@@ -88,9 +88,18 @@ class AHT20:
         return all_data, isCRC8_pass
         
 
+
     def get_temperature(self):
         # Get a measure, select proper bytes, return converted data
         measure = self.get_measure()
+        measure = ((measure[3] & 0xF) << 16) | (measure[4] << 8) | measure[5]
+        measure = measure / (pow(2,20))*200-50
+        return measure
+    def get_temperature_crc8(self):
+        isCRC8Pass = False
+        while (not isCRC8Pass): 
+            measure, isCRC8Pass = self.get_measure()
+            time.sleep(80 * 10**-3)
         measure = ((measure[3] & 0xF) << 16) | (measure[4] << 8) | measure[5]
         measure = measure / (pow(2,20))*200-50
         return measure
@@ -101,3 +110,14 @@ class AHT20:
         measure = (measure[1] << 12) | (measure[2] << 4) | (measure[3] >> 4)
         measure = measure * 100 / pow(2,20)
         return measure
+
+    def get_humidity_crc8(self):
+        isCRC8Pass = False
+        while (not isCRC8Pass): 
+            measure, isCRC8Pass = self.get_measure()
+            time.sleep(80 * 10**-3)
+        measure = (measure[1] << 12) | (measure[2] << 4) | (measure[3] >> 4)
+        measure = measure * 100 / pow(2,20)
+        return measure
+
+

--- a/AHT20.py
+++ b/AHT20.py
@@ -98,7 +98,7 @@ class AHT20:
     def get_temperature_crc8(self):
         isCRC8Pass = False
         while (not isCRC8Pass): 
-            measure, isCRC8Pass = self.get_measure()
+            measure, isCRC8Pass = self.get_measure_CRC8()
             time.sleep(80 * 10**-3)
         measure = ((measure[3] & 0xF) << 16) | (measure[4] << 8) | measure[5]
         measure = measure / (pow(2,20))*200-50
@@ -106,7 +106,7 @@ class AHT20:
 
     def get_humidity(self):
         # Get a measure, select proper bytes, return converted data
-        measure = self.get_measure_CRC8()
+        measure = self.get_measure()
         measure = (measure[1] << 12) | (measure[2] << 4) | (measure[3] >> 4)
         measure = measure * 100 / pow(2,20)
         return measure

--- a/AHT20.py
+++ b/AHT20.py
@@ -1,5 +1,6 @@
 from smbus2 import SMBus
 import time
+from crc8_helper import AHT20_crc8_check
 
 def get_normalized_bit(value, bit_index):
     # Return only one bit from value indicated in bit_index
@@ -75,6 +76,17 @@ class AHT20:
         # Read data and return it
         with SMBus(self.BusNum) as i2c_bus:
             return i2c_bus.read_i2c_block_data(AHT20_I2CADDR, 0x0, 7)
+
+    def get_measure_CRC8(self):
+        """
+        This function will calculate crc8 code with G(x) = x8 + x5 + x4 + 1 -> 0x131(0x31), Initial value = 0xFF. No XOROUT.
+        return: all_data (1 bytes status + 2.5 byes humidity + 2.5 bytes temperature + 1 bytes crc8 code), isCRC8_pass
+        """
+        all_data = self.get_measure()
+        isCRC8_pass = AHT20_crc8_check(all_data)
+
+        return all_data, isCRC8_pass
+        
 
     def get_temperature(self):
         # Get a measure, select proper bytes, return converted data

--- a/crc8_helper.py
+++ b/crc8_helper.py
@@ -1,0 +1,92 @@
+# Usage: AHT20 crc8 checker. 
+# A total of 6 * 8 bits data need to check. G(x) = x8 + x5 + x4 + 1 -> 0x131(0x31), Initial value = 0xFF. No XOROUT. 
+# Author: XU Zifeng. 
+# Email: zifeng.xu@foxmail.com
+N_DATA = 6
+# 1 * 8 bits CRC
+N_CRC = 1
+# Initial value. Equal to bit negation the first data (status of AHT20)
+INIT = 0xFF
+# Useful value to help calculate
+LAST_8_bit = 0xFF
+
+
+# Devide number retrieve from CRC-8 MAXIM G(x) = x8 + x5 + x4 + 1
+CRC_DEVIDE_NUMBER = 0x131
+
+# Data and CRC taken from AHT20, use this for testing?
+TEST_DATA = [[28, 184, 245, 165, 156, 208, 163], [28, 185, 16, 149, 156, 83, 112], [
+    28, 184, 249, 85, 156, 114, 213], [28, 185, 9, 53, 156, 54, 45], [28, 185, 70, 117, 156, 189, 33], [28, 185, 64, 165, 156, 61, 209]]
+
+
+def mod2_division_8bits(a, b, number_of_bytes, init_value):
+    "calculate mod2 division in 8 bits. a mod b. init_value is for crc8 init value."
+    head_of_a = 0x80
+    # Processiong a
+    a = a << 8
+    # Preprocessing head_of_a
+    for i in range(0, number_of_bytes):
+        head_of_a = head_of_a << 8
+        b = b << 8
+        init_value = init_value << 8
+    a = a ^ init_value
+    while (head_of_a > 0x80):
+        # Find a 1
+        if (head_of_a & a):
+            head_of_a = head_of_a >> 1
+            b = b >> 1
+            a = a ^ b
+        else:
+            head_of_a = head_of_a >> 1
+            b = b >> 1
+        print("a:{0}\thead of a:{1}\tb:{2}".format(
+            bin(a), bin(head_of_a), bin(b)))
+    return a
+
+
+def AHT20_crc8_calculate(all_data_int):
+    init_value = INIT
+    # Preprocess all the data and CRCCode from AHT20
+    data_from_AHT20 = 0x00
+    # Preprocessing the first data (status)
+    # print(bin(data_from_AHT20))
+    for i_data in range(0, len(all_data_int)):
+        data_from_AHT20 = (data_from_AHT20 << 8) | all_data_int[i_data]
+    # print(bin(data_from_AHT20))
+    mod_value = mod2_division_8bits(
+        data_from_AHT20, CRC_DEVIDE_NUMBER, len(all_data_int), init_value)
+    # print(mod_value)
+    return mod_value
+
+
+def AHT20_crc8_check(all_data_int):
+    """
+    The input data shoule be:
+    Status Humidity0 Humidity1 Humidity2|Temperature0 Temperature1 Temperature2 CRCCode.
+    In python's int64.
+    """
+    mod_value = AHT20_crc8_calculate(all_data_int[:-1])
+    if (mod_value == all_data_int[-1]):
+        return True
+    else:
+        return False
+
+
+
+def CRC8_check(all_data_int, init_value=0x00):
+    divider = 0x107
+    DATA_FOR_CHECK = all_data_int[0]
+    for data in all_data_int[1:-1]:
+        DATA_FOR_CHECK = (DATA_FOR_CHECK << 8) | data
+    remainder = mod2_division_8bits(
+        DATA_FOR_CHECK, divider, len(all_data_int) - 1, init_value)
+    if (remainder == all_data_int[-1]):
+        return True
+    else:
+        return False
+
+
+if __name__ == "__main__":
+    print(CRC8_check([0x66, 0x44, 0x33, 0x22, 0x24], 0))
+    for data in TEST_DATA:
+        print(AHT20_crc8_check(data))

--- a/crc8_helper.py
+++ b/crc8_helper.py
@@ -39,8 +39,9 @@ def mod2_division_8bits(a, b, number_of_bytes, init_value):
         else:
             head_of_a = head_of_a >> 1
             b = b >> 1
-        print("a:{0}\thead of a:{1}\tb:{2}".format(
-            bin(a), bin(head_of_a), bin(b)))
+        # This will show calculate the remainder
+        # print("a:{0}\thead of a:{1}\tb:{2}".format(
+        #     bin(a), bin(head_of_a), bin(b)))
     return a
 
 

--- a/example.py
+++ b/example.py
@@ -11,9 +11,12 @@ while 1:
 
     # Fill a string with date, humidity and temperature
     data = str(datetime.datetime.now()) + ";" + "{:10.2f}".format(aht20.get_humidity()) + " %RH;" + "{:10.2f}".format(aht20.get_temperature()) + " °C"
+    # Data with crc8 check
+    data_crc8 = str(datetime.datetime.now()) + ";" + "{:10.2f}".format(aht20.get_humidity_crc8()) + " %RH;" + "{:10.2f}".format(aht20.get_temperature_crc8()) + " °C"
 
     # Print in the console
     print(data)
+    print("data with crc check: {0}".format(data_crc8))
     
     # Append in a file
     log = open("log.txt", "a")


### PR DESCRIPTION
1. A crc8 checker implemented in pure python is done. G(x) = x8 + x5 + x4 + 1 -> 0x131(0x31), Initial value = 0xFF. No XOROUT. (ref: http://www.aosong.com/userfiles/files/media/AHT20%E4%BA%A7%E5%93%81%E8%A7%84%E6%A0%BC%E4%B9%A6(%E4%B8%AD%E6%96%87%E7%89%88)%20B2-0630.pdf)
2. I also write a package for AHT20 and DHT11 here (If you are interated in): https://github.com/xzf89718/sensors-control-gpio